### PR TITLE
[BE] Setting > CI/CD 자동화 파이프라인 구축 #19

### DIFF
--- a/.github/workflows/backend-cicd.yml
+++ b/.github/workflows/backend-cicd.yml
@@ -1,0 +1,59 @@
+name: Backend CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Build with Gradle
+        run: |
+          cd backend/server
+          ./gradlew clean build
+
+      - name: Package for deployment
+        run: |
+          mkdir -p deploy/
+          cp backend/server/cicd/appspec.yml deploy/
+          cp backend/server/cicd/*.sh deploy/
+          cp backend/server/build/libs/server-0.0.1-SNAPSHOT.jar deploy/
+          cp backend/server/cicd/Dockerfile deploy/
+          cp backend/server/cicd/docker-compose.yml deploy/
+          cd deploy
+          zip -r deployment-package.zip *
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp ./deploy/deployment-package.zip s3://todoc-s3-bucket/deployment-package.zip
+
+      - name: Deploy to EC2 with CodeDeploy
+        run: |
+          aws deploy create-deployment \
+            --application-name todoc-codedeploy \
+            --deployment-group-name ToDocAppCodeDeploy \
+            --deployment-config-name CodeDeployDefault.OneAtATime \
+            --s3-location bucket=todoc-s3-bucket,bundleType=zip,key=deployment-package.zip \
+            --region ap-northeast-2
+

--- a/.github/workflows/backend-pr-ci.yml
+++ b/.github/workflows/backend-pr-ci.yml
@@ -1,0 +1,41 @@
+name: Backend CI Test to develop
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "backend/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Build with Gradle
+        run: |
+          cd backend/server
+          ./gradlew clean build
+
+      - name: Run application in background
+        run: |
+          nohup java -jar backend/server/build/libs/server-0.0.1-SNAPSHOT.jar &
+          echo $! > app.pid
+          sleep 15
+
+      - name: Check application health
+        run: |
+          curl -f http://localhost:8080/actuator/health
+
+      - name: Stop application
+        run: |
+          kill -9 $(cat app.pid)

--- a/backend/server/build.gradle.kts
+++ b/backend/server/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
 	// ✅ Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 	implementation("org.apache.commons:commons-lang3:3.14.0")
+
+	// ✅ for health-check + 애플리케이션의 운영 및 모니터링 기능
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 
 val querydslDir = layout.buildDirectory.dir("generated/querydsl")

--- a/backend/server/cicd/Dockerfile
+++ b/backend/server/cicd/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21
+ARG JAR_FILE=server-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} /app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/backend/server/cicd/appspec.yml
+++ b/backend/server/cicd/appspec.yml
@@ -1,0 +1,12 @@
+version: 0.0
+os: linux
+
+files:
+  - source: /
+    destination: /home/ubuntu/app
+
+hooks:
+  AfterInstall:
+    - location: deploy.sh
+      timeout: 100
+      runas: ubuntu

--- a/backend/server/cicd/deploy.sh
+++ b/backend/server/cicd/deploy.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+APP_DIR="/home/ubuntu/app"
+cd "$APP_DIR"
+
+DEFAULT_CONF="/etc/nginx/nginx.conf"
+
+IS_BLUE=$(docker ps --format "{{.Names}}" | grep -w blue)
+IS_GREEN=$(docker ps --format "{{.Names}}" | grep -w green)
+
+# 상태 출력
+echo "현재 상태: BLUE=${IS_BLUE:+ON}, GREEN=${IS_GREEN:+ON}"
+
+# 1. 둘 다 안 떠 있을 경우 => blue 실행
+if [ -z "$IS_BLUE" ] && [ -z "$IS_GREEN" ]; then
+  echo "### 상태: 둘 다 꺼져 있음 => BLUE 실행 ###"
+  TARGET=blue
+  TARGET_PORT=8081
+  TARGET_CONF="/etc/nginx/nginx.blue.conf"
+  OTHER=green
+
+# 2. blue만 떠 있을 경우 => green 실행
+elif [ -n "$IS_BLUE" ] && [ -z "$IS_GREEN" ]; then
+  echo "### 상태: BLUE만 떠 있음 => GREEN 실행 ###"
+  TARGET=green
+  TARGET_PORT=8082
+  TARGET_CONF="/etc/nginx/nginx.green.conf"
+  OTHER=blue
+
+# 3. green만 떠 있을 경우 => blue 실행
+elif [ -z "$IS_BLUE" ] && [ -n "$IS_GREEN" ]; then
+  echo "### 상태: GREEN만 떠 있음 => BLUE 실행 ###"
+  TARGET=blue
+  TARGET_PORT=8081
+  TARGET_CONF="/etc/nginx/nginx.blue.conf"
+  OTHER=green
+
+# 4. 둘 다 떠 있음 => 에러 또는 선택적으로 처리
+else
+  echo "ERROR: BLUE와 GREEN 컨테이너가 둘 다 실행 중입니다."
+  echo "동시 실행은 허용되지 않으므로 스크립트를 종료합니다."
+  exit 1
+fi
+
+# 공통 로직
+echo "1. Build and start $TARGET container"
+docker compose build $TARGET
+docker compose up -d $TARGET
+
+SERVER_ADDRESS="http://localhost:$TARGET_PORT/actuator/health"
+echo "2. Health check ($SERVER_ADDRESS)"
+while true; do
+  sleep 3
+  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" $SERVER_ADDRESS)
+  if [ "$RESPONSE" -eq 200 ]; then
+    echo "Health check passed"
+    break
+  else
+    echo "Waiting for $TARGET to be healthy... (HTTP $RESPONSE)"
+  fi
+done
+
+echo "3. Reload nginx"
+sudo cp $TARGET_CONF $DEFAULT_CONF
+sudo nginx -s reload
+
+echo "4. Stop $OTHER container"
+docker compose stop $OTHER

--- a/backend/server/cicd/docker-compose.yml
+++ b/backend/server/cicd/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  blue:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: blue
+    ports:
+      - "8081:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+    restart: always
+
+  green:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: green
+    ports:
+      - "8082:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+    restart: always

--- a/backend/server/src/main/resources/application.yml
+++ b/backend/server/src/main/resources/application.yml
@@ -28,8 +28,11 @@ springdoc:
 
   show-actuator: false
 
-  servers:
-    - url: http://localhost:8080
-      description: "Local 개발 환경"
-    - url: https://api.example.com
-      description: "Production 서버"
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #19 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

**1. health-check 및 모니터링을 위한 라이브러리인 accuator를 `build.gradle.kts`에 추가했습니다.**
   - 서비스의 설정 정보 조회 및 health-check을 할 수 있는 라이브러리를 추가했습니다. 
   현재 사용하는 것에 비해 비효율적이라 판단되는데, 공통요소(Response,Exception)에 대한 코드 작성이 마무리 되면 healthCheck Controller를 작성해 blue-green 배포를 진행하려고 합니다.

**2. docker를 이용해 blue/green 배포 방식을 적용하기 위해 docker-compose와 Dockerfile 파일을 작성했습니다.**
   - `blue` 컨테이너는 `8081`포트, `green` 컨테이너는 `8082`포트로 생성하도록 했습니다.

**3. Github workflow를 작성했습니다.**
   - `main` 브랜치에 merge가 발생하면 CI/CD가 동작하도록 `backend-cicd.yml` 파일을 작성했습니다.
   - `develop` 브랜치에 pull request가 발생하면 CI 후 health-check을 통해 정상적으로 merge가 될지 테스트하는 `backend-pr-ci.yml` 파일을 작성했습니다.

---

## 💡 New Insights & Learnings


## 📢 To Reviewers

- 현재 RDS가 배포되지 않은 상태라, h2 memDB에 접속을 연결해야했습니다.
   이를 위해 우선은 `SPRING_PROFILES_ACTIVE=local` 설정을 적용해뒀습니다!  
   RDS 배포 후에는 prod 로 설정하여 적용해야 할 것 같습니다.
```
version: '3.8'

services:
  blue:
    build:
      context: .
      dockerfile: Dockerfile
    container_name: blue
    ports:
      - "8081:8080"
    environment:
      - SPRING_PROFILES_ACTIVE=local
    restart: always

...
```

- CI/CD에 대한 Github workflow 스크립트 수행 결과입니다.
   https://github.com/softeerbootcamp-6th/Team4-PopoPony/actions/runs/16613922245/job/47002561795


## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

### EC2 환경에서 blue/green 방식의 배포 성공 후 `docker ps` 실행 결과
<img width="948" height="67" alt="스크린샷 2025-07-30 오후 6 33 34" src="https://github.com/user-attachments/assets/c3b0ad45-8a88-4e38-8c45-1e7ac891e3bb" />

### EC2 원격 주소의 `/swagger-ui.html`에 접속한 화면
<img width="607" height="428" alt="스크린샷 2025-07-30 오후 6 37 03" src="https://github.com/user-attachments/assets/7c58ee86-1999-40d6-b422-aff3ec51f5f9" />

