### PR TITLE
[BE] Common > Response 공통 클래스 작성 #25

### DIFF
--- a/backend/server/src/main/java/com/todoc/server/common/response/ErrorResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/common/response/ErrorResponse.java
@@ -1,0 +1,34 @@
+package com.todoc.server.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"code", "status", "message", "timestamp"})
+public class ErrorResponse {
+    private final int code;
+    private final int status;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    private ErrorResponse(int code, int status, String message) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public static ErrorResponse from(ResponseStatus status) {
+        return new ErrorResponse(status.getCode(), status.getStatus(), status.getMessage());
+    }
+
+    public static ErrorResponse from(ResponseStatus status, String message) {
+        return new ErrorResponse(status.getCode(), status.getStatus(), message);
+    }
+
+    public static ErrorResponse from(ResponseStatus status, RuntimeException e) {
+        return new ErrorResponse(status.getCode(), status.getStatus(), e.getMessage());
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/common/response/Response.java
+++ b/backend/server/src/main/java/com/todoc/server/common/response/Response.java
@@ -1,0 +1,40 @@
+package com.todoc.server.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+import static com.todoc.server.common.response.ResponseStatus.SUCCESS;
+
+@Getter
+@JsonPropertyOrder({"code", "status", "message", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Response<T> {
+    private final int code;
+    private final int status;
+    private final String message;
+    private final T data;
+
+    private Response(int code, int status, String message, T data) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> Response<T> from() {
+        return new Response<>(SUCCESS.getCode(), SUCCESS.getStatus(), SUCCESS.getMessage(), null);
+    }
+
+    public static <T> Response<T> from(String message) {
+        return new Response<>(SUCCESS.getCode(), SUCCESS.getStatus(), message, null);
+    }
+
+    public static <T> Response<T> from(T data) {
+        return new Response<>(SUCCESS.getCode(), SUCCESS.getStatus(), SUCCESS.getMessage(), data);
+    }
+
+    public static <T> Response<T> from(String message, T data) {
+        return new Response<>(SUCCESS.getCode(), SUCCESS.getStatus(), message, data);
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/common/response/ResponseStatus.java
+++ b/backend/server/src/main/java/com/todoc/server/common/response/ResponseStatus.java
@@ -1,0 +1,18 @@
+package com.todoc.server.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseStatus {
+    SUCCESS(1000, HttpStatus.OK.value(), "Request was successful."),
+    BAD_REQUEST(2000, HttpStatus.BAD_REQUEST.value(), "Invalid request."),
+    NOT_FOUND(3000, HttpStatus.NOT_FOUND.value(), "No results found."),
+    INTERNAL_SERVER_ERROR(4000, HttpStatus.INTERNAL_SERVER_ERROR.value(), "An error occurred on the server.");
+
+    private final int code;
+    private final int status;
+    private final String message;
+}


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #25 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [ ] 테스트 코드 통과
- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

**1. `Response<T>` 제네릭 클래스 생성**
    - 성공 응답에 대한 정보를 제공
    - `code`, `status`, `message`, `data` 필드 포함
    - `from()` 팩토리 메서드 정의

**2. `ErrorResponse<T>` 제네릭 클래스 생성**
    - 실패 응답에 대한 정보를 제공
    - `code`, `status`, `message`, `timestamp` 필드 포함
    - `from()` 팩토리 메서드 정의

**3. `ResponseStatus` Enum 클래스 생성**
    - 응답의 상태 정보를 제공
    - code, status, message 필드 포함

---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

- ResponseStatus에는 기본적인 응답 상태들만 정의해두었습니다.
- `Response<T>`, `ErrorResponse<T>`는 외부에서 생성자를 통해 객체를 직접 생성하지 못하도록 했습니다.
    - `from()` 팩토리 메서드를 통해서만 객체를 생성할 수 있습니다.

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
