### PR TITLE
[BE] [SUB] Customer > 이전 동행 목록 불러오기 Service 계층 코드 작성 #152

### DIFF
--- a/backend/server/src/main/java/com/todoc/server/common/response/Response.java
+++ b/backend/server/src/main/java/com/todoc/server/common/response/Response.java
@@ -3,6 +3,7 @@ package com.todoc.server.common.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import static com.todoc.server.common.exception.global.CommonResponseCode.SUCCESS;
@@ -13,12 +14,15 @@ import static com.todoc.server.common.exception.global.CommonResponseCode.SUCCES
 @Schema(description = "공통 응답 포맷")
 public class Response<T> {
 
+    @NotNull
     @Schema(description = "직접 정의한 응답에 대한 code", example = "")
     private final int code;
 
+    @NotNull
     @Schema(description = "응답 상태에 대한 HTTP 상태 코드", example = "200")
     private final int status;
 
+    @NotNull
     @Schema(description = "응답 상태에 대한 HTTP 메시지", example = "SUCCESS")
     private final String message;
 

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/repository/RecruitQueryRepository.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/repository/RecruitQueryRepository.java
@@ -2,6 +2,8 @@ package com.todoc.server.domain.escort.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.todoc.server.domain.escort.repository.dto.RecruitHistoryDetailFlatDto;
+import com.todoc.server.domain.escort.web.dto.response.RecruitHistorySimpleResponse;
 import com.todoc.server.domain.route.entity.QLocationInfo;
 import java.util.List;
 import com.todoc.server.domain.escort.entity.Recruit;
@@ -24,6 +26,7 @@ public class RecruitQueryRepository {
 
     QLocationInfo meetingLocation = new QLocationInfo("meetingLocation");
     QLocationInfo hospitalLocation = new QLocationInfo("hospitalLocation");
+    QLocationInfo returnLocation = new QLocationInfo("returnLocation");
 
     public List<RecruitSimpleResponse> findListByUserId(Long userId) {
         List<RecruitSimpleResponse> result = queryFactory
@@ -65,6 +68,43 @@ public class RecruitQueryRepository {
                 .join(route.meetingLocationInfo, meetingLocation).fetchJoin()
                 .join(route.hospitalLocationInfo, hospitalLocation).fetchJoin()
                 .join(route.returnLocationInfo, returnLocation).fetchJoin()
+                .where(recruit.id.eq(recruitId))
+                .fetchOne();
+    }
+
+    public List<RecruitHistorySimpleResponse> findRecruitListSortedByUserId(Long userId, int limit) {
+        return queryFactory
+                .select(Projections.constructor(RecruitHistorySimpleResponse.class,
+                            recruit.id,
+                            patient.name,
+                            hospitalLocation.placeName,
+                            recruit.escortDate
+                ))
+                .from(recruit)
+                .join(recruit.patient, patient)
+                .join(recruit.route, route)
+                .join(route.hospitalLocationInfo, hospitalLocation)
+                .where(recruit.customer.id.eq(userId))
+                .orderBy(recruit.escortDate.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public RecruitHistoryDetailFlatDto getRecruitHistoryDetailByRecruitId(Long recruitId) {
+
+        return queryFactory
+                .select(Projections.constructor(RecruitHistoryDetailFlatDto.class,
+                        patient,
+                        meetingLocation,
+                        hospitalLocation,
+                        returnLocation
+                ))
+                .from(recruit)
+                .join(recruit.patient, patient)
+                .join(recruit.route, route)
+                .join(route.meetingLocationInfo, meetingLocation)
+                .join(route.hospitalLocationInfo, hospitalLocation)
+                .join(route.returnLocationInfo, returnLocation)
                 .where(recruit.id.eq(recruitId))
                 .fetchOne();
     }

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/repository/dto/RecruitHistoryDetailFlatDto.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/repository/dto/RecruitHistoryDetailFlatDto.java
@@ -1,0 +1,24 @@
+package com.todoc.server.domain.escort.repository.dto;
+
+import com.todoc.server.domain.customer.entity.Patient;
+import com.todoc.server.domain.route.entity.LocationInfo;
+import lombok.Getter;
+
+@Getter
+public class RecruitHistoryDetailFlatDto {
+
+    private Patient patient;
+
+    private LocationInfo meetingLocation;
+
+    private LocationInfo destination;
+
+    private LocationInfo returnLocation;
+
+    public RecruitHistoryDetailFlatDto(Patient patient, LocationInfo meetingLocation, LocationInfo destination, LocationInfo returnLocation) {
+        this.patient = patient;
+        this.meetingLocation = meetingLocation;
+        this.destination = destination;
+        this.returnLocation = returnLocation;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
@@ -116,6 +116,7 @@ public class RecruitService {
      * @param userId
      * @return 이전 동행 신청 목록 응답 DTO(RecruitHistoryListResponse) size = 5
      */
+    @Transactional(readOnly = true)
     public RecruitHistoryListResponse getRecruitHistoryListByUserId(Long userId) {
         List<RecruitHistorySimpleResponse> recruitList = recruitQueryRepository.findRecruitListSortedByUserId(userId, 5);
 
@@ -129,6 +130,7 @@ public class RecruitService {
      * @param recruitId
      * @return 동행 신청 상세 정보 DTO(RecruitHistoryDetailResponse)
      */
+    @Transactional(readOnly = true)
     public RecruitHistoryDetailResponse getRecruitHistoryDetailByRecruitId(Long recruitId) {
         RecruitHistoryDetailFlatDto recruitHistoryDetailFlatDto = recruitQueryRepository.getRecruitHistoryDetailByRecruitId(recruitId);
 

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
@@ -9,10 +9,10 @@ import com.todoc.server.domain.escort.exception.RecruitInvalidCancelException;
 import com.todoc.server.domain.escort.exception.RecruitNotFoundException;
 import com.todoc.server.domain.escort.repository.RecruitJpaRepository;
 import com.todoc.server.domain.escort.repository.RecruitQueryRepository;
+import com.todoc.server.domain.escort.repository.dto.RecruitHistoryDetailFlatDto;
 import com.todoc.server.domain.escort.web.dto.request.RecruitCreateRequest;
-import com.todoc.server.domain.escort.web.dto.response.RecruitDetailResponse;
-import com.todoc.server.domain.escort.web.dto.response.RecruitListResponse;
-import com.todoc.server.domain.escort.web.dto.response.RecruitSimpleResponse;
+import com.todoc.server.domain.escort.web.dto.response.*;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -109,6 +109,52 @@ public class RecruitService {
 
         // soft delete
         recruit.softDelete();
+    }
+
+    /**
+     * userId에 해당하는 고객의 이전 동행 신청 목록을 조회하는 함수
+     * @param userId
+     * @return 이전 동행 신청 목록 응답 DTO(RecruitHistoryListResponse) size = 5
+     */
+    public RecruitHistoryListResponse getRecruitHistoryListByUserId(Long userId) {
+        List<RecruitHistorySimpleResponse> recruitList = recruitQueryRepository.findRecruitListSortedByUserId(userId, 5);
+
+        return RecruitHistoryListResponse.builder()
+                .beforeList(recruitList)
+                .build();
+    }
+
+    /**
+     * recruitId에 해당하는 동행 신청에 대한 상세 정보를 조회하는 함수 (Request 형식과 동일한 형식의 Response DTO)
+     * @param recruitId
+     * @return 동행 신청 상세 정보 DTO(RecruitHistoryDetailResponse)
+     */
+    public RecruitHistoryDetailResponse getRecruitHistoryDetailByRecruitId(Long recruitId) {
+        RecruitHistoryDetailFlatDto recruitHistoryDetailFlatDto = recruitQueryRepository.getRecruitHistoryDetailByRecruitId(recruitId);
+
+        if (recruitHistoryDetailFlatDto == null) {
+            throw new RecruitNotFoundException();
+        }
+
+        // 환자 정보
+        Patient patient = recruitHistoryDetailFlatDto.getPatient();
+        RecruitHistoryDetailResponse.PatientDetail patientDetail =
+                RecruitHistoryDetailResponse.PatientDetail.from(patient);
+
+        // 위치 정보
+        RecruitHistoryDetailResponse.LocationDetail meetingLocationDetail = RecruitHistoryDetailResponse.LocationDetail
+                .from(recruitHistoryDetailFlatDto.getMeetingLocation());
+        RecruitHistoryDetailResponse.LocationDetail destinationDetail = RecruitHistoryDetailResponse.LocationDetail
+                .from(recruitHistoryDetailFlatDto.getDestination());
+        RecruitHistoryDetailResponse.LocationDetail returnLocationDetail = RecruitHistoryDetailResponse.LocationDetail
+                .from(recruitHistoryDetailFlatDto.getReturnLocation());
+
+        return RecruitHistoryDetailResponse.builder()
+                .patientDetail(patientDetail)
+                .meetingLocationDetail(meetingLocationDetail)
+                .destinationDetail(destinationDetail)
+                .returnLocationDetail(returnLocationDetail)
+                .build();
     }
 
     /**

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/controller/RecruitController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/controller/RecruitController.java
@@ -74,6 +74,9 @@ public class RecruitController {
     public Response<RecruitHistoryListResponse> getRecruitHistoryList() {
         // TODO :: 원래라면 jwt 혹은 sessionId로부터 유저 정보를 조회해야 함
         // 현재는 우선 userId = 1로 고정
+        //
+        // recruitService.getRecruitHistoryListByUserId(1L);
+
         RecruitHistorySimpleResponse dto = RecruitHistorySimpleResponse.builder()
                 .recruitId(1L)
                 .name("김토닥")
@@ -101,7 +104,9 @@ public class RecruitController {
             description = "이전 환자(동행)에 대한 기록 조회 성공 ")
     @GetMapping("/{recruitId}/history")
     public Response<RecruitHistoryDetailResponse> getRecruitHistory(@PathVariable Long recruitId) {
-
+        // TODO :: 원래라면 jwt 혹은 sessionId로부터 유저 정보를 조회해야 함
+        // 현재는 우선 userId = 1로 고정
+        // recruitService.getRecruitHistoryDetailByRecruitId(recruitId);
 
         RecruitHistoryDetailResponse.PatientDetail patientDetail = RecruitHistoryDetailResponse.PatientDetail.builder()
                 .patientId(1L)

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitHistoryDetailResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitHistoryDetailResponse.java
@@ -1,5 +1,9 @@
 package com.todoc.server.domain.escort.web.dto.response;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.todoc.server.common.util.JsonUtils;
+import com.todoc.server.domain.customer.entity.Patient;
+import com.todoc.server.domain.route.entity.LocationInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -70,6 +74,27 @@ public class RecruitHistoryDetailResponse {
         @Schema(description = "의사소통 이슈가 있다면, 디테일 설명", example = "이가 많이 없으셔서.. 천천히 이야기 들어주세요")
         private String communicationIssueDetail;
 
+        public static PatientDetail from(Patient patient) {
+
+            List<String> cognitiveIssueDetail = JsonUtils.fromJson(patient.getCognitiveIssueDetail(), new TypeReference<>() {});
+            String gender = patient.getGender().getLabel();
+
+            return PatientDetail.builder()
+                    .patientId(patient.getId())
+                    .imageUrl(patient.getImageUrl())
+                    .name(patient.getName())
+                    .age(patient.getAge())
+                    .gender(gender)
+                    .phoneNumber(patient.getContact())
+                    .needsHelping(patient.getNeedsHelping())
+                    .usesWheelchair(patient.getUsesWheelchair())
+                    .hasCognitiveIssue(patient.getHasCognitiveIssue())
+                    .cognitiveIssueDetail(cognitiveIssueDetail)
+                    .hasCommunicationIssue(patient.getHasCommunicationIssue())
+                    .communicationIssueDetail(patient.getCommunicationIssueDetail())
+                    .build();
+        }
+
         @Builder
         public PatientDetail(Long patientId, String imageUrl, String name, Integer age, String gender, String phoneNumber,
                              boolean needsHelping, boolean usesWheelchair, boolean hasCognitiveIssue,
@@ -127,6 +152,23 @@ public class RecruitHistoryDetailResponse {
 
         @Schema(description = "위도 (Latitude)", example = "36.4809912")
         private BigDecimal latitude;
+
+        public static LocationDetail from(LocationInfo locationInfo) {
+            return LocationDetail.builder()
+                    .placeName(locationInfo.getPlaceName())
+                    .upperAddrName(locationInfo.getUpperAddrName())
+                    .middleAddrName(locationInfo.getMiddleAddrName())
+                    .lowerAddrName(locationInfo.getLowerAddrName())
+                    .firstAddrNo(locationInfo.getFirstAddrNo())
+                    .secondAddrNo(locationInfo.getSecondAddrNo())
+                    .roadName(locationInfo.getRoadName())
+                    .firstBuildingNo(locationInfo.getFirstBuildingNo())
+                    .secondBuildingNo(locationInfo.getSecondBuildingNo())
+                    .detailAddress(locationInfo.getDetailAddress())
+                    .longitude(locationInfo.getLongitude())
+                    .latitude(locationInfo.getLatitude())
+                    .build();
+        }
 
         @Builder
         public LocationDetail(String placeName, String upperAddrName, String middleAddrName, String lowerAddrName,


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #152 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [ ] 테스트 코드 통과
- [ ] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 이전 동행 목록 불러오기 / 이전 동행 신청 정보 불러오기에 대한 Serivce 및 Repsoitory 코드를 작성했습니다.
   - 각각 `/api/recruits/patients` `/api/recruits/{recruitId}/history` API에서 사용합니다.
   - flatDTO 클래스에 `from()`함수를 추가했습니다.
2. 프론트엔드 분들의 요청에 따라 Response 클래스의 필드에도 `@NotNull`애노테이션을 추가했습니다.

---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

- FlatDto 사용이 적절한지, 다른 방법이 있을지 피드백해주시면 감사하겠습니다!
- 테스트코드는 추후 PR에서 리뷰를 받고 머지하겠습니다.

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
