### PR TITLE
[BE] [SUB] Auth > 로그인 기능 구현 #170

### DIFF
--- a/backend/server/build.gradle.kts
+++ b/backend/server/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
 
 	// for health-check + 애플리케이션의 운영 및 모니터링 기능
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+	// 로그인 비밀번호 처리
+	implementation("org.mindrot:jbcrypt:0.4")
 }
 
 val querydslDir = layout.buildDirectory.dir("generated/querydsl")

--- a/backend/server/src/main/java/com/todoc/server/common/config/WebConfig.java
+++ b/backend/server/src/main/java/com/todoc/server/common/config/WebConfig.java
@@ -1,11 +1,20 @@
 package com.todoc.server.common.config;
 
+import com.todoc.server.domain.auth.web.AuthInterceptor;
+import com.todoc.server.domain.auth.web.LoginUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final AuthInterceptor authInterceptor;
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -13,6 +22,14 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:3000", "https://team4-popopony.vercel.app")// React 개발 서버 Origin
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH") // 허용 메서드
                 .allowedHeaders("*") // 모든 헤더 허용
-                .allowCredentials(true); // 인증 정보(쿠키 등) 포함 허용
+                .allowCredentials(true) // 인증 정보(쿠키 등) 포함 허용
+                .maxAge(3600); // CORS preflight 요청의 캐시 시간 (1시간)
+    }
+
+    @Override public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor).addPathPatterns("/api/**");
+    }
+    @Override public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
     }
 }

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/exception/AuthErrorCode.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ResponseCode {
 
     // 사용자(auth)
-    NOT_FOUND(11001, HttpStatus.NOT_FOUND.value(), "유저가 존재하지 않습니다.")
+    NOT_FOUND(11001, HttpStatus.NOT_FOUND.value(), "유저가 존재하지 않습니다."),
+    UNAUTHORIZED(11005, HttpStatus.UNAUTHORIZED.value(), "접근 권한이 없습니다.")
     ;
 
     private final int code;

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/exception/AuthUnAuthorizedException.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/exception/AuthUnAuthorizedException.java
@@ -1,0 +1,9 @@
+package com.todoc.server.domain.auth.exception;
+
+import com.todoc.server.common.exception.base.CustomException;
+
+public class AuthUnAuthorizedException extends CustomException {
+    public AuthUnAuthorizedException() {
+        super(AuthErrorCode.UNAUTHORIZED);
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/repository/AuthJpaRepository.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/repository/AuthJpaRepository.java
@@ -1,7 +1,9 @@
 package com.todoc.server.domain.auth.repository;
 
 import com.todoc.server.domain.auth.entity.Auth;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthJpaRepository extends JpaRepository<Auth, Long> {
+    Optional<Auth> findByLoginId(String loginId);
 }

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/service/AuthService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/service/AuthService.java
@@ -4,8 +4,12 @@ import com.todoc.server.domain.auth.entity.Auth;
 import com.todoc.server.domain.auth.exception.AuthNotFoundException;
 import com.todoc.server.domain.auth.repository.AuthJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.mindrot.jbcrypt.BCrypt.checkpw;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final AuthJpaRepository authJpaRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthService.class);
 
     /**
      * 주어진 ID에 해당하는 Auth 엔티티를 조회합니다.
@@ -23,6 +29,18 @@ public class AuthService {
     public Auth getAuthById(Long authId) {
         return authJpaRepository.findById(authId)
                 .orElseThrow(AuthNotFoundException::new);
+    }
+
+    public SessionAuth authenticate(String username, String password) {
+        Auth auth = authJpaRepository.findByLoginId(username)
+            .orElseThrow(AuthNotFoundException::new);
+
+        if (!checkpw(password, auth.getPassword())) {
+            throw new AuthNotFoundException();
+        }
+
+        logger.info("[AuthService] - 로그인 성공 : {}", auth.getLoginId());
+        return new SessionAuth(auth.getId(), auth.getLoginId());
     }
 
 

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/service/SessionAuth.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/service/SessionAuth.java
@@ -1,0 +1,3 @@
+package com.todoc.server.domain.auth.service;
+
+public record SessionAuth(Long id, String loginId) {}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/AuthInterceptor.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/AuthInterceptor.java
@@ -1,0 +1,32 @@
+package com.todoc.server.domain.auth.web;
+
+import com.todoc.server.domain.auth.service.SessionAuth;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String uri = request.getRequestURI();
+
+        // 화이트리스트
+        if (uri.startsWith("/api/auth") || uri.startsWith("v3/api-docs") || uri.startsWith("/swagger-ui")) {
+            return true;
+        }
+
+        HttpSession session = request.getSession(false);
+        SessionAuth auth = (session == null) ? null : (SessionAuth) session.getAttribute("AUTH_USER");
+        if (auth == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/LoginUser.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/LoginUser.java
@@ -1,0 +1,12 @@
+package com.todoc.server.domain.auth.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+    boolean required() default true; // 로그인 유저가 반드시 필요한지 여부
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/LoginUserArgumentResolver.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/LoginUserArgumentResolver.java
@@ -1,0 +1,36 @@
+package com.todoc.server.domain.auth.web;
+
+import com.todoc.server.domain.auth.service.SessionAuth;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class) && SessionAuth.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest req = (HttpServletRequest) webRequest.getNativeRequest();
+        HttpSession session = req.getSession(false);
+        SessionAuth auth = (session == null) ? null : (SessionAuth) session.getAttribute("AUTH_USER");
+
+        boolean required = parameter.getParameterAnnotation(LoginUser.class).required();
+        if (auth == null && required) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        return auth;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/controller/AuthController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/controller/AuthController.java
@@ -1,0 +1,56 @@
+package com.todoc.server.domain.auth.web.controller;
+
+import com.todoc.server.common.response.Response;
+import com.todoc.server.domain.auth.exception.AuthUnAuthorizedException;
+import com.todoc.server.domain.auth.service.AuthService;
+import com.todoc.server.domain.auth.service.SessionAuth;
+import com.todoc.server.domain.auth.web.dto.request.LoginRequest;
+import com.todoc.server.domain.auth.web.dto.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public Response<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
+        // 1. 자격 검증
+        SessionAuth auth = authService.authenticate(loginRequest.getLoginId(),
+            loginRequest.getPassword());
+
+        // 2. 이전 세션 폐기 후 새 세션 발급
+        HttpSession old = request.getSession(false);
+        if (old != null) {
+            old.invalidate();
+        }
+        HttpSession session = request.getSession(true);
+
+        // 3. 세션에 유저/CSRF 저장
+        session.setAttribute("AUTH_USER", auth);
+
+        return Response.from(LoginResponse.from(auth));
+    }
+
+    @GetMapping("/me")
+    public Response<LoginResponse> me(HttpServletRequest request, HttpServletResponse response) {
+        HttpSession session = request.getSession(false);
+        SessionAuth auth = (session == null) ? null : (SessionAuth) session.getAttribute("AUTH_USER");
+
+        if (auth == null){
+            throw new AuthUnAuthorizedException();
+        }
+
+        return Response.from(LoginResponse.from(auth));
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/dto/request/LoginRequest.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/dto/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.todoc.server.domain.auth.web.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    private String loginId;
+    private String password;
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/auth/web/dto/response/LoginResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/auth/web/dto/response/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.todoc.server.domain.auth.web.dto.response;
+
+import com.todoc.server.domain.auth.service.SessionAuth;
+
+public record LoginResponse(Long userId, String username) {
+    public static LoginResponse from(SessionAuth u) {
+        return new LoginResponse(u.id(), u.loginId());
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/controller/RecruitController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/controller/RecruitController.java
@@ -2,6 +2,9 @@ package com.todoc.server.domain.escort.web.controller;
 
 import com.todoc.server.common.enumeration.RecruitStatus;
 import com.todoc.server.common.response.Response;
+import com.todoc.server.domain.auth.entity.Auth;
+import com.todoc.server.domain.auth.service.SessionAuth;
+import com.todoc.server.domain.auth.web.LoginUser;
 import com.todoc.server.domain.customer.web.dto.response.PatientSimpleResponse;
 import com.todoc.server.domain.escort.service.RecruitFacadeService;
 import com.todoc.server.domain.escort.service.RecruitService;
@@ -39,9 +42,11 @@ public class RecruitController {
             responseCode = "200",
             description = "동행 목록 조회 성공" )
     @GetMapping("/customer")
-    public Response<RecruitListResponse> getRecruitListAsCustomer() {
+    public Response<RecruitListResponse> getRecruitListAsCustomer(@LoginUser SessionAuth auth) {
+
         // TODO :: 원래라면 jwt 혹은 sessionId로부터 유저 정보를 조회해야 함
         // 현재는 우선 userId = 1로 고정
+        String loginId = auth.loginId();
 
         RecruitSimpleResponse dto = RecruitSimpleResponse.builder()
                 .recruitId(1L)


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #170 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [ ] 테스트 코드 통과
- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 유저 조회 함수 및 예외 클래스를 작성했습니다.
2. 로그인 성공시 Set-Cookie를 통해 SessionId를 클라이언트에게 전달하도록 했습니다.
3. `@LoginUser` 애노테이션을 통해, Controller에서 세션을 통해 유저의 정보를 조회할 수 있도록 했습니다. 왜케 입력미

---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

-

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
`api/auth/login` 응답 바디
<img width="778" height="373" alt="스크린샷 2025-08-11 오후 2 51 56" src="https://github.com/user-attachments/assets/f172b035-4105-4143-9690-6f3cf2221511" />

`api/auth/login` 응답 헤더
<img width="778" height="373" alt="image" src="https://github.com/user-attachments/assets/17431260-284b-4b8d-9663-39aedf5ad128" />

`/api/recruits/customer`
<img width="778" height="373" alt="image" src="https://github.com/user-attachments/assets/85b9f1bb-2e99-4cdc-ba09-5ed5843c7a76" />
