### PR TITLE
[BE] [SUB] Recruit > Recruit History 조회 기능 수정 #214

### DIFF
--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitHistoryDetailResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitHistoryDetailResponse.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.todoc.server.common.util.ImageUrlUtils;
 import com.todoc.server.common.util.JsonUtils;
 import com.todoc.server.domain.customer.entity.Patient;
+import com.todoc.server.domain.image.entity.ImageFile;
+import com.todoc.server.domain.image.entity.ImageMeta;
 import com.todoc.server.domain.route.entity.LocationInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -36,6 +38,22 @@ public class RecruitHistoryDetailResponse {
         @NotNull
         @Schema(description = "환자 이미지 URL", example = "https://example.com/patient.png")
         private String imageUrl;
+
+        @NotNull
+        @Schema(description = "S3 오브젝트 키(버킷 내부 경로). presigned 업로드 시 사용했던 key 그대로 전달")
+        private String s3Key;
+
+        @NotNull
+        @Schema(description = "원본 Content-Type (이미지 MIME 타입)")
+        private String contentType;
+
+        @NotNull
+        @Schema(description = "파일 크기(byte)")
+        private Long size;
+
+        @NotNull
+        @Schema(description = "무결성 해시(일반적으로 S3 ETag)")
+        private String checksum;
 
         @NotNull
         @Schema(description = "환자 이름", example = "홍길동")
@@ -79,10 +97,16 @@ public class RecruitHistoryDetailResponse {
 
             List<String> cognitiveIssueDetail = JsonUtils.fromJson(patient.getCognitiveIssueDetail(), new TypeReference<>() {});
             String gender = patient.getGender().getLabel();
+            ImageFile patientImage = patient.getPatientProfileImage();
+            ImageMeta imageMeta = patientImage.getImageMeta();
 
             return PatientDetail.builder()
                     .patientId(patient.getId())
-                    .imageUrl(ImageUrlUtils.getImageUrl(patient.getPatientProfileImage().getId()))
+                    .imageUrl(ImageUrlUtils.getImageUrl(patientImage.getId()))
+                    .s3Key(imageMeta.getS3Key())
+                    .contentType(imageMeta.getContentType())
+                    .size(imageMeta.getSize())
+                    .checksum(imageMeta.getChecksum())
                     .name(patient.getName())
                     .age(patient.getAge())
                     .gender(gender)
@@ -97,11 +121,13 @@ public class RecruitHistoryDetailResponse {
         }
 
         @Builder
-        public PatientDetail(Long patientId, String imageUrl, String name, Integer age, String gender, String phoneNumber,
-                             boolean needsHelping, boolean usesWheelchair, boolean hasCognitiveIssue,
-                             List<String> cognitiveIssueDetail, boolean hasCommunicationIssue, String communicationIssueDetail) {
+        public PatientDetail(Long patientId, String imageUrl, String s3Key, String contentType, Long size, String checksum, String name, Integer age, String gender, String phoneNumber, boolean needsHelping, boolean usesWheelchair, boolean hasCognitiveIssue, List<String> cognitiveIssueDetail, boolean hasCommunicationIssue, String communicationIssueDetail) {
             this.patientId = patientId;
             this.imageUrl = imageUrl;
+            this.s3Key = s3Key;
+            this.contentType = contentType;
+            this.size = size;
+            this.checksum = checksum;
             this.name = name;
             this.age = age;
             this.gender = gender;

--- a/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitServiceTest.java
+++ b/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitServiceTest.java
@@ -13,6 +13,7 @@ import com.todoc.server.domain.escort.repository.RecruitQueryRepository;
 import com.todoc.server.domain.escort.repository.dto.RecruitHistoryDetailFlatDto;
 import com.todoc.server.domain.escort.web.dto.response.*;
 import com.todoc.server.domain.image.entity.ImageFile;
+import com.todoc.server.domain.image.entity.ImageMeta;
 import com.todoc.server.domain.route.entity.LocationInfo;
 import java.util.ArrayList;
 import java.util.Map;
@@ -197,8 +198,10 @@ class RecruitServiceTest {
 
         // 이미지 스텁 (핵심)
         ImageFile img = mock(ImageFile.class);
+        ImageMeta imageMeta = mock(ImageMeta.class);
         when(img.getId()).thenReturn(3001L);
         when(patient.getPatientProfileImage()).thenReturn(img);
+        when(img.getImageMeta()).thenReturn(imageMeta);
 
         try (MockedStatic<ImageUrlUtils> urlMock = mockStatic(ImageUrlUtils.class)) {
             urlMock.when(() -> ImageUrlUtils.getImageUrl(3001L))


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #214 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [x] 테스트 코드 통과
- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. Recruit History를 불러오면, image Metadata와 url을 반환하도록 수정
---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

-

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="1186" height="928" alt="스크린샷 2025-08-14 오전 11 42 54" src="https://github.com/user-attachments/assets/5330c6a4-1b98-44db-abd4-ec317bc04e94" />
