### PR TITLE
[BE] [SUB] Recruit > RecruitSimpleResponse에 동행 상태 필드 추가 #225

### DIFF
--- a/backend/server/src/main/java/com/todoc/server/common/enumeration/EscortStatus.java
+++ b/backend/server/src/main/java/com/todoc/server/common/enumeration/EscortStatus.java
@@ -7,13 +7,13 @@ import java.util.Optional;
 
 @Getter
 public enum EscortStatus {
-    PREPARING("동행 준비"),
-    MEETING("만남 중"),
+    PREPARING("동행준비"),
+    MEETING("만남중"),
     HEADING_TO_HOSPITAL("병원행"),
-    IN_TREATMENT("진료 중"),
-    RETURNING("복귀 중"),
-    WRITING_REPORT("리포트 작성 중"),
-    DONE("동행 완료");
+    IN_TREATMENT("진료중"),
+    RETURNING("복귀중"),
+    WRITING_REPORT("리포트작성중"),
+    DONE("동행완료");
 
     private final String label;
 

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/repository/RecruitQueryRepository.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/repository/RecruitQueryRepository.java
@@ -39,6 +39,7 @@ public class RecruitQueryRepository {
                 recruit.id,
                 escort.id,
                 recruit.status,
+                escort.status,
                 application.count(),
                 recruit.escortDate,
                 recruit.estimatedMeetingTime,
@@ -59,7 +60,7 @@ public class RecruitQueryRepository {
             .join(route.hospitalLocationInfo, hospitalLocation)
             .join(recruit.patient, patient)
             .where(recruit.customer.id.eq(userId))
-            .groupBy(recruit.id)
+            .groupBy(recruit.id, escort.id, escort.status)
             .fetch();
 
         return result;
@@ -153,6 +154,7 @@ public class RecruitQueryRepository {
                 recruit.id,
                 escort.id,
                 recruit.status,
+                escort.status,
                 application.count(),
                 recruit.escortDate,
                 recruit.estimatedMeetingTime,
@@ -175,7 +177,7 @@ public class RecruitQueryRepository {
             .where(application.helper.id.eq(helperUserId)
                 .and(application.status.in(status))
                 .and(application.deletedAt.isNull()))
-            .groupBy(recruit.id)
+            .groupBy(recruit.id, escort.id, escort.status)
             .fetch();
     }
 

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/service/RecruitService.java
@@ -59,7 +59,7 @@ public class RecruitService {
 
         // 진행중인 목록과 완료된 목록 분리
         for (RecruitSimpleResponse recruit : rawList) {
-            if (RecruitStatus.from(recruit.getStatus()).get() == RecruitStatus.DONE) {
+            if (RecruitStatus.from(recruit.getRecruitStatus()).get() == RecruitStatus.DONE) {
                 completedList.add(recruit);
             } else {
                 inProgressList.add(recruit);
@@ -68,7 +68,7 @@ public class RecruitService {
 
         // 진행중인 목록의 경우, 진행중인 목록 먼저 필터링 하고, 이후에 동행일 기준 오름차순 정렬
         inProgressList.sort(Comparator
-            .comparing((RecruitSimpleResponse r) -> RecruitStatus.from(r.getStatus()).get() != RecruitStatus.IN_PROGRESS)
+            .comparing((RecruitSimpleResponse r) -> RecruitStatus.from(r.getRecruitStatus()).get() != RecruitStatus.IN_PROGRESS)
             .thenComparing(RecruitSimpleResponse::getEscortDate)
         );
 
@@ -267,7 +267,7 @@ public class RecruitService {
 
         // 진행중인 목록과 완료된 목록 분리
         for (RecruitSimpleResponse recruit : rawList) {
-            if (RecruitStatus.from(recruit.getStatus()).get() == RecruitStatus.DONE) {
+            if (RecruitStatus.from(recruit.getRecruitStatus()).get() == RecruitStatus.DONE) {
                 completedList.add(recruit);
             } else {
                 inProgressList.add(recruit);
@@ -276,7 +276,7 @@ public class RecruitService {
 
         // 진행중인 목록의 경우, 진행중인 목록 먼저 필터링 하고, 이후에 동행일 기준 오름차순 정렬
         inProgressList.sort(Comparator
-            .comparing((RecruitSimpleResponse r) -> RecruitStatus.from(r.getStatus()).get() != RecruitStatus.IN_PROGRESS)
+            .comparing((RecruitSimpleResponse r) -> RecruitStatus.from(r.getRecruitStatus()).get() != RecruitStatus.IN_PROGRESS)
             .thenComparing(RecruitSimpleResponse::getEscortDate)
         );
 
@@ -334,7 +334,7 @@ public class RecruitService {
             RecruitSimpleResponse dto = RecruitSimpleResponse.builder()
                 .recruitId(recruit.getId())
                 .escortId(null)
-                .status(recruit.getStatus().getLabel())
+                .recruitStatus(recruit.getStatus().getLabel())
                 .numberOfApplication(0L)
                 .escortDate(recruit.getEscortDate())
                 .estimatedMeetingTime(recruit.getEstimatedMeetingTime())

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitSimpleResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/RecruitSimpleResponse.java
@@ -1,5 +1,6 @@
 package com.todoc.server.domain.escort.web.dto.response;
 
+import com.todoc.server.common.enumeration.EscortStatus;
 import com.todoc.server.common.enumeration.RecruitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -24,7 +25,10 @@ public class RecruitSimpleResponse {
     // 매칭중, 매칭완료, 동행중
     @NotNull
     @Schema(description = "동행 신청의 진행 상태", allowableValues = {"매칭중", "매칭완료", "동행중", "동행완료"})
-    private String status;
+    private String recruitStatus;
+
+    @Schema(description = "실제 동행의 진행 상태", allowableValues = {"동행준비", "만남중", "병원행", "진료중", "복귀중", "리포트작성중", "동행완료"})
+    private String escortStatus;
 
     @NotNull
     @Schema(description = "지원한 도우미 수")
@@ -71,10 +75,11 @@ public class RecruitSimpleResponse {
     private Boolean hasCommunicationIssue;
 
     @Builder
-    public RecruitSimpleResponse(Long recruitId, Long escortId, String status, Long numberOfApplication, LocalDate escortDate, LocalTime estimatedMeetingTime, LocalTime estimatedReturnTime, String departureLocation, String destination, Integer estimatedPayment, Boolean needsHelping, Boolean usesWheelchair, Boolean hasCognitiveIssue, Boolean hasCommunicationIssue) {
+    public RecruitSimpleResponse(Long recruitId, Long escortId, String recruitStatus, String escortStatus, Long numberOfApplication, LocalDate escortDate, LocalTime estimatedMeetingTime, LocalTime estimatedReturnTime, String departureLocation, String destination, Integer estimatedPayment, Boolean needsHelping, Boolean usesWheelchair, Boolean hasCognitiveIssue, Boolean hasCommunicationIssue) {
         this.recruitId = recruitId;
         this.escortId = escortId;
-        this.status = status;
+        this.recruitStatus = recruitStatus;
+        this.escortStatus = escortStatus;
         this.numberOfApplication = numberOfApplication;
         this.escortDate = escortDate;
         this.estimatedMeetingTime = estimatedMeetingTime;
@@ -89,10 +94,13 @@ public class RecruitSimpleResponse {
     }
 
     @Builder
-    public RecruitSimpleResponse(Long recruitId, Long escortId, RecruitStatus status, Long numberOfApplication, LocalDate escortDate, LocalTime estimatedMeetingTime, LocalTime estimatedReturnTime, String departureLocation, String destination, Integer estimatedPayment, Boolean needsHelping, Boolean usesWheelchair, Boolean hasCognitiveIssue, Boolean hasCommunicationIssue) {
+    public RecruitSimpleResponse(Long recruitId, Long escortId, RecruitStatus recruitStatus, EscortStatus escortStatus, Long numberOfApplication, LocalDate escortDate, LocalTime estimatedMeetingTime, LocalTime estimatedReturnTime, String departureLocation, String destination, Integer estimatedPayment, Boolean needsHelping, Boolean usesWheelchair, Boolean hasCognitiveIssue, Boolean hasCommunicationIssue) {
+        String escortStatusLabel = escortStatus == null ? escortStatusLabel = null : escortStatus.getLabel();
+
         this.recruitId = recruitId;
         this.escortId = escortId;
-        this.status = status.getLabel();
+        this.recruitStatus = recruitStatus.getLabel();
+        this.escortStatus = escortStatusLabel;
         this.numberOfApplication = numberOfApplication;
         this.escortDate = escortDate;
         this.estimatedMeetingTime = estimatedMeetingTime;

--- a/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitIntegrationTest.java
+++ b/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitIntegrationTest.java
@@ -235,19 +235,19 @@ public class RecruitIntegrationTest {
 
         // 진행중: DONE 제외 날짜 오름차순
         var inProgress = res.getInProgressList();
-        assertThat(inProgress.stream().map(RecruitSimpleResponse::getStatus))
+        assertThat(inProgress.stream().map(RecruitSimpleResponse::getRecruitStatus))
                 .doesNotContain(RecruitStatus.DONE.getLabel());
         if (!inProgress.isEmpty()) {
             System.out.println(inProgress.size());
             for (RecruitSimpleResponse recruitSimpleResponse : inProgress) {
-                assertThat(recruitSimpleResponse.getStatus()).isNotEqualTo(RecruitStatus.DONE.getLabel());
+                assertThat(recruitSimpleResponse.getRecruitStatus()).isNotEqualTo(RecruitStatus.DONE.getLabel());
             }
             assertThat(inProgress).isSortedAccordingTo(Comparator.comparing(RecruitSimpleResponse::getEscortDate));
         }
 
         // 완료: 전부 DONE, 날짜 내림차순
         var completed = res.getCompletedList();
-        assertThat(completed.stream().map(RecruitSimpleResponse::getStatus))
+        assertThat(completed.stream().map(RecruitSimpleResponse::getRecruitStatus))
                 .allMatch(s -> s.equals(RecruitStatus.DONE.getLabel()));
         if (completed.size() > 1) {
             assertThat(completed).isSortedAccordingTo(
@@ -287,7 +287,7 @@ public class RecruitIntegrationTest {
                 assertThat(item.getDestination()).isNotBlank();
                 assertThat(item.getEstimatedMeetingTime()).isNotNull();
                 assertThat(item.getEstimatedReturnTime()).isNotNull();
-                assertThat(item.getStatus()).isEqualTo(RecruitStatus.MATCHING.getLabel());
+                assertThat(item.getRecruitStatus()).isEqualTo(RecruitStatus.MATCHING.getLabel());
             });
         });
     }

--- a/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitServiceTest.java
+++ b/backend/server/src/test/java/com/todoc/server/domain/escort/service/RecruitServiceTest.java
@@ -59,11 +59,11 @@ class RecruitServiceTest {
     public void getRecruitListAsCustomerByUserId_ShouldReturnSortedRecruitList() {
         // given
         Long userId = 1L;
-        RecruitSimpleResponse inProgress1 = new RecruitSimpleResponse(1L,1L, "동행중", 2L, LocalDate.of(2024, 6, 3), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
-        RecruitSimpleResponse inProgress2 = new RecruitSimpleResponse(1L, 2L, "동행중", 2L, LocalDate.of(2024, 6, 1), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
-        RecruitSimpleResponse inProgress3 = new RecruitSimpleResponse(2L, null, "매칭중", 3L, LocalDate.of(2024, 6, 2), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원B", 10000, true, false, false, true);
-        RecruitSimpleResponse done1 = new RecruitSimpleResponse(3L, null, "동행완료", 2L, LocalDate.of(2024, 5, 30), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원C", 10000, true, false, false, true);
-        RecruitSimpleResponse done2 = new RecruitSimpleResponse(4L, null, "동행완료", 1L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원D", 10000, true, false, false, true);
+        RecruitSimpleResponse inProgress1 = new RecruitSimpleResponse(1L,1L, "동행중", "동행준비", 2L, LocalDate.of(2024, 6, 3), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
+        RecruitSimpleResponse inProgress2 = new RecruitSimpleResponse(1L, 2L, "동행중", "만남중", 2L, LocalDate.of(2024, 6, 1), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
+        RecruitSimpleResponse inProgress3 = new RecruitSimpleResponse(2L, null, "매칭중", null, 3L, LocalDate.of(2024, 6, 2), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원B", 10000, true, false, false, true);
+        RecruitSimpleResponse done1 = new RecruitSimpleResponse(3L, null, "동행완료", "리포트작성중", 2L, LocalDate.of(2024, 5, 30), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원C", 10000, true, false, false, true);
+        RecruitSimpleResponse done2 = new RecruitSimpleResponse(4L, null, "동행완료", "동행완료", 1L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원D", 10000, true, false, false, true);
 
         List<RecruitSimpleResponse> mockList = Arrays.asList(inProgress2, done1, inProgress1, done2, inProgress3);
 
@@ -77,11 +77,13 @@ class RecruitServiceTest {
         assertEquals(2, result.getCompletedList().size());
 
         // 진행중인 목록: IN_PROGRESS가 최상단, 날짜 오름차순
-        assertEquals("동행중", result.getInProgressList().get(0).getStatus());
+        assertEquals("동행중", result.getInProgressList().get(0).getRecruitStatus());
+        assertNotNull(result.getInProgressList().get(0).getEscortStatus());
         assertTrue(result.getInProgressList().get(0).getEscortDate().isBefore(result.getInProgressList().get(1).getEscortDate()));
 
         // 완료된 목록: 날짜 내림차순
-        assertEquals("동행완료", result.getCompletedList().get(0).getStatus());
+        assertEquals("동행완료", result.getCompletedList().get(0).getRecruitStatus());
+        assertNotNull(result.getCompletedList().get(0).getEscortStatus());
         assertTrue(result.getCompletedList().get(0).getEscortDate().isAfter(result.getCompletedList().get(1).getEscortDate()));
     }
 
@@ -308,11 +310,11 @@ class RecruitServiceTest {
         // given
         Long helperUserId = 7L;
 
-        RecruitSimpleResponse r1 = new RecruitSimpleResponse(1L, 1L, "동행중", 2L, LocalDate.of(2024, 6, 3), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
-        RecruitSimpleResponse r2 = new RecruitSimpleResponse(2L, null, "매칭중", 3L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원B", 10000, true, false, false, true);
-        RecruitSimpleResponse r3 = new RecruitSimpleResponse(3L, 3L, "매칭완료", 4L, LocalDate.of(2024, 6, 2), LocalTime.NOON, LocalTime.MIDNIGHT, "시청역", "병원C", 10000, true, false, false, true);
-        RecruitSimpleResponse r4 = new RecruitSimpleResponse(4L, 4L, "동행완료", 5L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "강남역", "병원D", 10000, true, false, false, true);
-        RecruitSimpleResponse r5 = new RecruitSimpleResponse(5L, 5L, "동행완료", 6L, LocalDate.of(2024, 5, 30), LocalTime.NOON, LocalTime.MIDNIGHT, "교대역", "병원E", 10000, true, false, false, true);
+        RecruitSimpleResponse r1 = new RecruitSimpleResponse(1L, 1L, "동행중", "동행준비", 2L, LocalDate.of(2024, 6, 3), LocalTime.NOON, LocalTime.MIDNIGHT, "서울역", "병원A", 10000, true, false, false, true);
+        RecruitSimpleResponse r2 = new RecruitSimpleResponse(2L, null, "매칭중", null, 3L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "학동역", "병원B", 10000, true, false, false, true);
+        RecruitSimpleResponse r3 = new RecruitSimpleResponse(3L, 3L, "매칭완료", null, 4L, LocalDate.of(2024, 6, 2), LocalTime.NOON, LocalTime.MIDNIGHT, "시청역", "병원C", 10000, true, false, false, true);
+        RecruitSimpleResponse r4 = new RecruitSimpleResponse(4L, 4L, "동행완료", "리포트작성중", 5L, LocalDate.of(2024, 6, 4), LocalTime.NOON, LocalTime.MIDNIGHT, "강남역", "병원D", 10000, true, false, false, true);
+        RecruitSimpleResponse r5 = new RecruitSimpleResponse(5L, 5L, "동행완료", "동행완료", 6L, LocalDate.of(2024, 5, 30), LocalTime.NOON, LocalTime.MIDNIGHT, "교대역", "병원E", 10000, true, false, false, true);
 
         when(recruitQueryRepository.findListByHelperUserIdAndApplicationStatus(
             eq(helperUserId), eq(List.of(ApplicationStatus.MATCHED, ApplicationStatus.PENDING))))
@@ -329,15 +331,15 @@ class RecruitServiceTest {
         List<RecruitSimpleResponse> inProgress = result.getInProgressList();
 
         assertEquals(1L, inProgress.get(0).getRecruitId());  // r1 (동행중이므로 첫번째로 와야함)
-        assertEquals("동행중", inProgress.get(0).getStatus());
+        assertEquals("동행중", inProgress.get(0).getRecruitStatus());
         assertEquals(LocalDate.of(2024, 6, 3), inProgress.get(0).getEscortDate());
 
         assertEquals(3L, inProgress.get(1).getRecruitId()); // r3 (매칭중/매칭완료 상태의 경우 동행일 기준 오름차순이므로 r3가 두번째로 와야함)
-        assertEquals("매칭완료", inProgress.get(1).getStatus());
+        assertEquals("매칭완료", inProgress.get(1).getRecruitStatus());
         assertEquals(LocalDate.of(2024, 6, 2), inProgress.get(1).getEscortDate());
 
         assertEquals(2L, inProgress.get(2).getRecruitId()); // r2 (동행중 상태가 아님, 동행일 기준 오름차순이므로 마지막에 와야함)
-        assertEquals("매칭중", inProgress.get(2).getStatus());
+        assertEquals("매칭중", inProgress.get(2).getRecruitStatus());
         assertEquals(LocalDate.of(2024, 6, 4), inProgress.get(2).getEscortDate());
 
         // 완료 목록


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #225 

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [x] 테스트 코드 통과
- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. `RecruitSimpleResponse`에 대해 recruitStatus와 escortStatus로 분리했습니다.
2. `RecruitSimpleResponse`가 변경함에 따라, `RecruitRepository.findListByUserId()`, `RecruitRepository.findListByHelperUserIdAndApplicationStatus()` 쿼리를 수정했습니다.
3. 테스트코드를 함께 수정했습니다.

---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

-

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="403" height="419" alt="스크린샷 2025-08-14 오후 8 08 22" src="https://github.com/user-attachments/assets/741b663c-2a6f-4429-ad76-6302efebcae8" />

<img width="1186" height="928" alt="스크린샷 2025-08-14 오후 8 02 30" src="https://github.com/user-attachments/assets/36b55907-b7ec-48d0-97a9-d312b031ae10" />
