### PR TITLE
[BE] [SUB] Dashboard > Server - Customer SSE 통신 구현 #230

### DIFF
--- a/backend/server/src/main/java/com/todoc/server/domain/escort/entity/Escort.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/entity/Escort.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLRestriction;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -35,10 +35,10 @@ public class Escort extends BaseEntity {
     private Auth helper;
 
     @Column(name = "actual_meeting_time")
-    private LocalTime actualMeetingTime;
+    private LocalDateTime actualMeetingTime;
 
     @Column(name = "actual_return_time")
-    private LocalTime actualReturnTime;
+    private LocalDateTime actualReturnTime;
 
     private String memo;
 

--- a/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/EscortStatusResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/escort/web/dto/response/EscortStatusResponse.java
@@ -1,0 +1,32 @@
+package com.todoc.server.domain.escort.web.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "동행 상태 변화 응답 DTO")
+public class EscortStatusResponse {
+
+    @NotNull
+    @Schema(description = "동행 ID")
+    private Long escortId;
+
+    @NotNull
+    @Schema(description = "동행 상태", example = "병원행")
+    private String escortStatus;
+
+    @NotNull
+    @Schema(description = "동행 상태", example = "병원행")
+    private LocalDateTime timestamp;
+
+    public EscortStatusResponse(Long escortId, String escortStatus, LocalDateTime timestamp) {
+        this.escortId = escortId;
+        this.escortStatus = escortStatus;
+        this.timestamp = timestamp;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/report/web/dto/response/ReportDefaultValueResponse.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/report/web/dto/response/ReportDefaultValueResponse.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Schema(description = "리포트 작성 기본값 응답 DTO")
@@ -13,18 +13,18 @@ public class ReportDefaultValueResponse {
 
     @NotNull
     @Schema(description = "실제 만난 시각", example = "09:30:00")
-    private LocalTime actualMeetingTime;
+    private LocalDateTime actualMeetingTime;
 
     @NotNull
     @Schema(description = "실제 복귀 시각", example = "12:30:00")
-    private LocalTime actualReturnTime;
+    private LocalDateTime actualReturnTime;
 
     @NotNull
     @Schema(description = "동행 중 메모", example = "증상 전보다 많이 호전됨")
     private String memo;
 
     @Builder
-    public ReportDefaultValueResponse(LocalTime actualMeetingTime, LocalTime actualReturnTime, String memo) {
+    public ReportDefaultValueResponse(LocalDateTime actualMeetingTime, LocalDateTime actualReturnTime, String memo) {
         this.actualMeetingTime = actualMeetingTime;
         this.actualReturnTime = actualReturnTime;
         this.memo = memo;

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
@@ -7,43 +7,92 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 public class SseEmitterManager {
 
-    // escortId별로 SSE 구독자 목록을 관리
-    private final ConcurrentHashMap<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+//    // escortId별로 SSE 구독자 목록을 관리
+//    private final ConcurrentHashMap<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+//
+//    public SseEmitter addEmitter(Long escortId) {
+//        SseEmitter emitter = new SseEmitter(0L); // 타임아웃 없음
+//        emitters.computeIfAbsent(escortId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+//
+//        emitter.onCompletion(() -> removeEmitter(escortId, emitter));
+//        emitter.onTimeout(() -> removeEmitter(escortId, emitter));
+//        emitter.onError(e -> removeEmitter(escortId, emitter));
+//
+//        return emitter;
+//    }
+//
+//    public void sendToEscort(Long escortId, String eventName, Object data) {
+//        List<SseEmitter> emitterList = emitters.get(escortId);
+//        if (emitterList == null) return;
+//
+//        for (SseEmitter emitter : emitterList) {
+//            try {
+//                emitter.send(SseEmitter.event()
+//                        .name(eventName)
+//                        .data(data));
+//            } catch (IOException e) {
+//                removeEmitter(escortId, emitter);
+//            }
+//        }
+//    }
+//
+//    private void removeEmitter(Long escortId, SseEmitter emitter) {
+//        List<SseEmitter> emitterList = emitters.get(escortId);
+//        if (emitterList != null) {
+//            emitterList.remove(emitter);
+//        }
+//    }
 
-    public SseEmitter addEmitter(Long escortId) {
-        SseEmitter emitter = new SseEmitter(0L); // 타임아웃 없음
-        emitters.computeIfAbsent(escortId, k -> new CopyOnWriteArrayList<>()).add(emitter);
 
-        emitter.onCompletion(() -> removeEmitter(escortId, emitter));
-        emitter.onTimeout(() -> removeEmitter(escortId, emitter));
-        emitter.onError(e -> removeEmitter(escortId, emitter));
+    // escortId -> 단 하나의 Emitter만 보관
+    private final ConcurrentHashMap<Long, AtomicReference<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-        return emitter;
+    /** 새 연결 등록(기존 연결이 있으면 끊고 교체) */
+    public SseEmitter register(Long escortId) {
+        SseEmitter newEmitter = new SseEmitter(0L); // 무제한 타임아웃
+        AtomicReference<SseEmitter> ref =
+                emitters.computeIfAbsent(escortId, k -> new AtomicReference<>());
+
+        SseEmitter prev = ref.getAndSet(newEmitter);
+        if (prev != null) {
+            // 동일 동행에 중복 접속 시 이전 연결 종료(의도적으로 하나만 유지)
+            safeComplete(prev);
+        }
+
+        // 연결 라이프사이클에 맞춰 자동 정리
+        Runnable cleanup = () -> {
+            // 내가 현재 등록된 emitter인 경우에만 제거(경쟁상황 대비)
+            ref.compareAndSet(newEmitter, null);
+        };
+        newEmitter.onCompletion(cleanup);
+        newEmitter.onTimeout(cleanup);
+        newEmitter.onError(t -> cleanup.run());
+
+        return newEmitter;
     }
 
-    public void sendToEscort(Long escortId, String eventName, Object data) {
-        List<SseEmitter> emitterList = emitters.get(escortId);
-        if (emitterList == null) return;
+    /** 단일 구독자에게 이벤트 전송(없으면 무시) */
+    public void send(Long escortId, String eventName, Object data) {
+        AtomicReference<SseEmitter> ref = emitters.get(escortId);
+        if (ref == null) return;
+        SseEmitter e = ref.get();
+        if (e == null) return;
 
-        for (SseEmitter emitter : emitterList) {
-            try {
-                emitter.send(SseEmitter.event()
-                        .name(eventName)
-                        .data(data));
-            } catch (IOException e) {
-                removeEmitter(escortId, emitter);
-            }
+        try {
+            e.send(SseEmitter.event().name(eventName).data(data));
+        } catch (IOException ex) {
+            // 전송 실패 시 현재 등록된 연결이면 정리
+            ref.compareAndSet(e, null);
+            safeComplete(e);
         }
     }
 
-    private void removeEmitter(Long escortId, SseEmitter emitter) {
-        List<SseEmitter> emitterList = emitters.get(escortId);
-        if (emitterList != null) {
-            emitterList.remove(emitter);
-        }
+    private void safeComplete(SseEmitter e) {
+        try { e.complete(); } catch (Exception ignore) {}
     }
 }

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
@@ -4,71 +4,30 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 public class SseEmitterManager {
 
-//    // escortId별로 SSE 구독자 목록을 관리
-//    private final ConcurrentHashMap<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
-//
-//    public SseEmitter addEmitter(Long escortId) {
-//        SseEmitter emitter = new SseEmitter(0L); // 타임아웃 없음
-//        emitters.computeIfAbsent(escortId, k -> new CopyOnWriteArrayList<>()).add(emitter);
-//
-//        emitter.onCompletion(() -> removeEmitter(escortId, emitter));
-//        emitter.onTimeout(() -> removeEmitter(escortId, emitter));
-//        emitter.onError(e -> removeEmitter(escortId, emitter));
-//
-//        return emitter;
-//    }
-//
-//    public void sendToEscort(Long escortId, String eventName, Object data) {
-//        List<SseEmitter> emitterList = emitters.get(escortId);
-//        if (emitterList == null) return;
-//
-//        for (SseEmitter emitter : emitterList) {
-//            try {
-//                emitter.send(SseEmitter.event()
-//                        .name(eventName)
-//                        .data(data));
-//            } catch (IOException e) {
-//                removeEmitter(escortId, emitter);
-//            }
-//        }
-//    }
-//
-//    private void removeEmitter(Long escortId, SseEmitter emitter) {
-//        List<SseEmitter> emitterList = emitters.get(escortId);
-//        if (emitterList != null) {
-//            emitterList.remove(emitter);
-//        }
-//    }
+    // escortId 별로 단 하나의 Emitter만 보관
+    private final ConcurrentHashMap<Long, AtomicReference<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
 
-
-    // escortId -> 단 하나의 Emitter만 보관
-    private final ConcurrentHashMap<Long, AtomicReference<SseEmitter>> emitters = new ConcurrentHashMap<>();
-
-    /** 새 연결 등록(기존 연결이 있으면 끊고 교체) */
+    /**
+     * 새 연결 등록(기존 연결이 있으면 끊고 교체)
+     * */
     public SseEmitter register(Long escortId) {
         SseEmitter newEmitter = new SseEmitter(0L); // 무제한 타임아웃
-        AtomicReference<SseEmitter> ref =
-                emitters.computeIfAbsent(escortId, k -> new AtomicReference<>());
+        AtomicReference<SseEmitter> box = emitterMap.computeIfAbsent(escortId, k -> new AtomicReference<>());
 
-        SseEmitter prev = ref.getAndSet(newEmitter);
-        if (prev != null) {
+        SseEmitter prevEmitter = box.getAndSet(newEmitter);
+        if (prevEmitter != null) {
             // 동일 동행에 중복 접속 시 이전 연결 종료(의도적으로 하나만 유지)
-            safeComplete(prev);
+            safeComplete(prevEmitter);
         }
 
         // 연결 라이프사이클에 맞춰 자동 정리
-        Runnable cleanup = () -> {
-            // 내가 현재 등록된 emitter인 경우에만 제거(경쟁상황 대비)
-            ref.compareAndSet(newEmitter, null);
-        };
+        Runnable cleanup = () -> box.compareAndSet(newEmitter, null);
         newEmitter.onCompletion(cleanup);
         newEmitter.onTimeout(cleanup);
         newEmitter.onError(t -> cleanup.run());
@@ -76,23 +35,24 @@ public class SseEmitterManager {
         return newEmitter;
     }
 
-    /** 단일 구독자에게 이벤트 전송(없으면 무시) */
-    public void send(Long escortId, String eventName, Object data) {
-        AtomicReference<SseEmitter> ref = emitters.get(escortId);
-        if (ref == null) return;
-        SseEmitter e = ref.get();
-        if (e == null) return;
-
+    /** 단일 구독자에게 이벤트 전송 */
+    public void sendEvent(Long escortId, String eventName, Object data) {
+        AtomicReference<SseEmitter> box = emitterMap.get(escortId);
+        if (box == null)
+            return;
+        SseEmitter emitter = box.get();
+        if (emitter == null)
+            return;
         try {
-            e.send(SseEmitter.event().name(eventName).data(data));
+            emitter.send(SseEmitter.event().name(eventName).data(data));
         } catch (IOException ex) {
             // 전송 실패 시 현재 등록된 연결이면 정리
-            ref.compareAndSet(e, null);
-            safeComplete(e);
+            box.compareAndSet(emitter, null);
+            safeComplete(emitter);
         }
     }
 
-    private void safeComplete(SseEmitter e) {
-        try { e.complete(); } catch (Exception ignore) {}
+    private void safeComplete(SseEmitter emitter) {
+        try { emitter.complete(); } catch (Exception ignore) {}
     }
 }

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseEmitterManager.java
@@ -1,0 +1,49 @@
+package com.todoc.server.domain.sse.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+public class SseEmitterManager {
+
+    // escortId별로 SSE 구독자 목록을 관리
+    private final ConcurrentHashMap<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter addEmitter(Long escortId) {
+        SseEmitter emitter = new SseEmitter(0L); // 타임아웃 없음
+        emitters.computeIfAbsent(escortId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        emitter.onCompletion(() -> removeEmitter(escortId, emitter));
+        emitter.onTimeout(() -> removeEmitter(escortId, emitter));
+        emitter.onError(e -> removeEmitter(escortId, emitter));
+
+        return emitter;
+    }
+
+    public void sendToEscort(Long escortId, String eventName, Object data) {
+        List<SseEmitter> emitterList = emitters.get(escortId);
+        if (emitterList == null) return;
+
+        for (SseEmitter emitter : emitterList) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data));
+            } catch (IOException e) {
+                removeEmitter(escortId, emitter);
+            }
+        }
+    }
+
+    private void removeEmitter(Long escortId, SseEmitter emitter) {
+        List<SseEmitter> emitterList = emitters.get(escortId);
+        if (emitterList != null) {
+            emitterList.remove(emitter);
+        }
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseService.java
@@ -1,4 +1,0 @@
-package com.todoc.server.domain.sse.service;
-
-public class SseService {
-}

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseService.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/service/SseService.java
@@ -1,0 +1,4 @@
+package com.todoc.server.domain.sse.service;
+
+public class SseService {
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/LocationController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/LocationController.java
@@ -1,0 +1,29 @@
+package com.todoc.server.domain.sse.web.controller;
+
+import com.todoc.server.domain.sse.service.SseEmitterManager;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/locations")
+public class LocationController {
+
+    private final SseEmitterManager emitterManager;
+
+    // 도우미가 현재 위치 전송
+    @PostMapping
+    public void updateLocation(@RequestBody LocationDto location) {
+        // 여기서 DB 저장이나 검증 로직 추가 가능
+        emitterManager.sendToEscort(location.getEscortId(), "update", location);
+    }
+
+    @Data
+    public static class LocationDto {
+        private Long escortId;
+        private double lat;
+        private double lng;
+        private double accuracy;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/LocationController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/LocationController.java
@@ -15,8 +15,8 @@ public class LocationController {
     // 도우미가 현재 위치 전송
     @PostMapping
     public void updateLocation(@RequestBody LocationDto location) {
-        // 여기서 DB 저장이나 검증 로직 추가 가능
-        emitterManager.sendToEscort(location.getEscortId(), "update", location);
+        // TODO :: 추후에 진짜 Controller와 연결
+        emitterManager.sendEvent(location.getEscortId(), "location", location);
     }
 
     @Data

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/SseController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/SseController.java
@@ -1,0 +1,38 @@
+package com.todoc.server.domain.sse.web.controller;
+
+import com.todoc.server.domain.sse.service.SseEmitterManager;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+
+@Tag(name = "recruits", description = "동행 신청 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/realtime")
+public class SseController {
+
+    private final SseEmitterManager emitterManager;
+
+    // 고객이 도우미 위치 구독
+    @GetMapping(value = "/escorts/{escortId}/helper-location", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable Long escortId) {
+        SseEmitter emitter = emitterManager.addEmitter(escortId);
+
+        // 연결 직후 스냅샷(예: "NO_DATA") 전송
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("snapshot")
+                    .data("NO_DATA"));
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+}

--- a/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/SseController.java
+++ b/backend/server/src/main/java/com/todoc/server/domain/sse/web/controller/SseController.java
@@ -11,28 +11,27 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
-@Tag(name = "recruits", description = "동행 신청 관련 API")
+@Tag(name = "sse", description = "SSE 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/realtime")
+@RequestMapping("/api/sse")
 public class SseController {
 
     private final SseEmitterManager emitterManager;
 
     // 고객이 도우미 위치 구독
-    @GetMapping(value = "/escorts/{escortId}/helper-location", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/escorts/{escortId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@PathVariable Long escortId) {
-        SseEmitter emitter = emitterManager.addEmitter(escortId);
 
-        // 연결 직후 스냅샷(예: "NO_DATA") 전송
+        SseEmitter emitter = emitterManager.register(escortId);
+
+        // 연결 직후 스냅샷 전송
+        // TODO :: 도우미 마지막 위치 전달
         try {
-            emitter.send(SseEmitter.event()
-                    .name("snapshot")
-                    .data("NO_DATA"));
+            emitter.send(SseEmitter.event().name("snapshot").data("NO_DATA"));
         } catch (Exception e) {
             emitter.completeWithError(e);
         }
-
         return emitter;
     }
 }


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->

## 📌 Related Issue Number

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #230

---

## Checklist

- [x] 🌿 Base 브랜치를 올바르게 설정했나요?
- [x] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [x] ✅ 빌드와 테스트는 모두 성공했나요?
- [x] 📦 코드의 책임이 명확하게 분리되었나요?
- [x] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [x] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [x] 👥 리뷰어를 지정했나요?
- [x] 🏷️ 라벨을 올바르게 등록했나요?

---

## 🧪 Test Method

- [ ] 테스트 코드 통과
- [x] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. `SseController` : SSE 연결을 위한 컨트롤러 클래스 구현
   - 처음 SSE 연결되었을 때, 스냅샷으로 도우미의 마지막 위치 전송(추가 구현 필요)
2. `SseEmitterManager` : `SseEmitter`들을 관리하기 위한 매니저 클래스 구현
   - `Map` 구조로 `escortId` 하나당 하나의 `SseEmitter`만 생성되도록 관리
   - 동일한 연결에서 `eventName`(location, status)을 통해 실시간 위치에 대한 데이터인지, 진행 상태 변화에 대한 데이터인지 구분
3. `LocationController` : 도우미 실시간 위치 갱신을 테스트하기 위한 임시 클래스 구현
    - 추후에 제대로 구현된 컨트롤러(혹은 서비스)와 연결 필요
4. `EscortService`: 진행 상태 변화 시 `SseEmitterManager`를 통해 상태 변화 이벤트 전달
    - 진행 상태 변화에 대한 `timestamp`를 `LocalDateTime` 타입으로 변경

---

## 💡 New Insights & Learnings

-

## 📢 To Reviewers

- Postman으로 이벤트 제대로 전송되는지 확인했습니다.

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="1247" height="401" alt="스크린샷 2025-08-17 오후 4 31 40" src="https://github.com/user-attachments/assets/21456697-d3ae-4b8b-b02d-402afa54c711" />
